### PR TITLE
Fix #10: Rename CDL to RNH CDL

### DIFF
--- a/cdl_convert/cdl_convert.py
+++ b/cdl_convert/cdl_convert.py
@@ -134,10 +134,10 @@ __all__ = [
     'parse_ale',
     'parse_cc',
     'parse_ccc',
-    'parse_cdl',
+    'parse_rnh_cdl',
     'parse_flex',
     'write_cc',
-    'write_cdl',
+    'write_rnh_cdl',
 ]
 
 # ==============================================================================
@@ -2253,7 +2253,7 @@ def parse_ccc(input_file):
 # ==============================================================================
 
 
-def parse_cdl(input_file):
+def parse_rnh_cdl(input_file):
     """Parses a space separated .cdl file for ASC CDL information.
 
     **Args:**
@@ -2531,7 +2531,7 @@ def write_ccc(cdl):
 # ==============================================================================
 
 
-def write_cdl(cdl):
+def write_rnh_cdl(cdl):
     """Writes the ColorCorrection to a space separated .cdl file"""
 
     values = list(cdl.slope)
@@ -2556,14 +2556,14 @@ INPUT_FORMATS = {
     'ale': parse_ale,
     'ccc': parse_ccc,
     'cc': parse_cc,
-    'cdl': parse_cdl,
+    'cdl': parse_rnh_cdl,
     'flex': parse_flex,
 }
 
 OUTPUT_FORMATS = {
     'cc': write_cc,
     'ccc': write_ccc,
-    'cdl': write_cdl,
+    'cdl': write_rnh_cdl,
 }
 
 COLLECTION_FORMATS = ['ale', 'ccc', 'flex']

--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -95,7 +95,7 @@ class TestParseCDLBasic(unittest.TestCase):
             f.write(enc(self.file))
             self.filename = f.name
 
-        self.cdl = cdl_convert.parse_cdl(self.filename)
+        self.cdl = cdl_convert.parse_rnh_cdl(self.filename)
 
     #==========================================================================
 
@@ -179,7 +179,7 @@ class TestParseCDLOdd(TestParseCDLBasic):
             f.write(enc(self.file))
             self.filename = f.name
 
-        self.cdl = cdl_convert.parse_cdl(self.filename)
+        self.cdl = cdl_convert.parse_rnh_cdl(self.filename)
 
 
 class TestWriteCDLBasic(unittest.TestCase):
@@ -211,7 +211,7 @@ class TestWriteCDLBasic(unittest.TestCase):
         self.mockOpen = mock.mock_open()
 
         with mock.patch(builtins + '.open', self.mockOpen, create=True):
-            cdl_convert.write_cdl(self.cdl)
+            cdl_convert.write_rnh_cdl(self.cdl)
 
     def tearDown(self):
         # We need to clear the ColorCorrection member dictionary so we don't
@@ -229,7 +229,7 @@ class TestWriteCDLBasic(unittest.TestCase):
     #==========================================================================
 
     def testContent(self):
-        """Tests that write_cdl wrote the correct CDL"""
+        """Tests that write_rnh_cdl wrote the correct CDL"""
         handle = self.mockOpen()
         handle.write.assert_called_once_with(enc(self.file))
 
@@ -265,7 +265,7 @@ class TestWriteCDLOdd(TestWriteCDLBasic):
         self.mockOpen = mock.mock_open()
 
         with mock.patch(builtins + '.open', self.mockOpen, create=True):
-            cdl_convert.write_cdl(self.cdl)
+            cdl_convert.write_rnh_cdl(self.cdl)
 
 #==============================================================================
 # FUNCTIONS

--- a/tests/test_cdl_convert.py
+++ b/tests/test_cdl_convert.py
@@ -589,7 +589,7 @@ class TestMain(unittest.TestCase):
         cdl_convert.main()
 
         mockParse.assert_called_once_with('file.ccc')
-        
+
     #==========================================================================
 
     @mock.patch('cdl_convert.cdl_convert.parse_cc')
@@ -611,7 +611,7 @@ class TestMain(unittest.TestCase):
 
     #==========================================================================
 
-    @mock.patch('cdl_convert.cdl_convert.parse_cdl')
+    @mock.patch('cdl_convert.cdl_convert.parse_rnh_cdl')
     @mock.patch('os.path.abspath')
     def testDerivingInputTypeCDL(self, abspath, mockParse):
         """Tests that input type will be derived from file extension"""
@@ -627,7 +627,7 @@ class TestMain(unittest.TestCase):
         cdl_convert.main()
 
         mockParse.assert_called_once_with('file.cdl')
-        
+
     #==========================================================================
 
     @mock.patch('cdl_convert.cdl_convert.parse_flex')
@@ -670,7 +670,7 @@ class TestMain(unittest.TestCase):
 
     @mock.patch('os.path.dirname')
     @mock.patch('cdl_convert.cdl_convert.write_cc')
-    @mock.patch('cdl_convert.cdl_convert.parse_cdl')
+    @mock.patch('cdl_convert.cdl_convert.parse_rnh_cdl')
     @mock.patch('os.path.abspath')
     def testDetermineDestCalled(self, abspath, mockParse, mockWrite, dirname):
         """Tests that we try and write a converted file"""
@@ -752,7 +752,7 @@ class TestMain(unittest.TestCase):
     #==========================================================================
 
     @mock.patch('cdl_convert.cdl_convert.write_cc')
-    @mock.patch('cdl_convert.cdl_convert.parse_cdl')
+    @mock.patch('cdl_convert.cdl_convert.parse_rnh_cdl')
     @mock.patch('os.path.abspath')
     def testWriteCalled(self, abspath, mockParse, mockWrite):
         """Tests that we try and write a converted file"""
@@ -776,7 +776,7 @@ class TestMain(unittest.TestCase):
 
     #==========================================================================
 
-    @mock.patch('cdl_convert.cdl_convert.write_cdl')
+    @mock.patch('cdl_convert.cdl_convert.write_rnh_cdl')
     @mock.patch('cdl_convert.cdl_convert.write_cc')
     @mock.patch('cdl_convert.cdl_convert.parse_ccc')
     @mock.patch('os.path.abspath')


### PR DESCRIPTION
I renamed the calls to parse_cdl and write_cdl as per the issue. I did not yet update the documentation but I suspect that's something we'll want to do. Tests fully pass.
