### PR TITLE
correction: fix SatNode tag

### DIFF
--- a/cdl_convert/correction.py
+++ b/cdl_convert/correction.py
@@ -537,7 +537,7 @@ class SatNode(ColorNodeBase):
 
     def build_element(self):
         """Builds an ElementTree XML Element representing this SatNode"""
-        sat = ElementTree.Element('SATNode')
+        sat = ElementTree.Element('SatNode')
         for description in self.desc:
             desc = ElementTree.SubElement(sat, 'Description')
             desc.text = description

--- a/tests/test_cc.py
+++ b/tests/test_cc.py
@@ -60,11 +60,11 @@ CC_FULL = """<?xml version="1.0" encoding="UTF-8"?>
         <Description>Sop description 3</Description>
     </SOPNode>
     <Description>CC description 3</Description>
-    <SATNode>
+    <SatNode>
         <Description>Sat description 1</Description>
         <Saturation>1.09</Saturation>
         <Description>Sat description 2</Description>
-    </SATNode>
+    </SatNode>
     <Description>CC description 4</Description>
     <ViewingDescription>Viewing Desc Text</ViewingDescription>
     <Description>CC description 5</Description>
@@ -215,11 +215,11 @@ CC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
         <Offset>-0.00315 -0.00124 0.3103</Offset>
         <Power>1.0 0.9983 1.0</Power>
     </SOPNode>
-    <SATNode>
+    <SatNode>
         <Description>Sat description 1</Description>
         <Description>Sat description 2</Description>
         <Saturation>1.09</Saturation>
-    </SATNode>
+    </SatNode>
 </ColorCorrection>
 """
 
@@ -236,18 +236,18 @@ CC_ODD_WRITE = r"""<?xml version="1.0" encoding="UTF-8"?>
         <Offset>-3424.011 -342789423.013 -4238923.11</Offset>
         <Power>3271893.993 0.0000998 0.0000000000000000113</Power>
     </SOPNode>
-    <SATNode>
+    <SatNode>
         <Saturation>1798787.01</Saturation>
-    </SATNode>
+    </SatNode>
 </ColorCorrection>
 """
 
 CC_NO_SOP_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
 <ColorCorrection id="burp_200.x15">
-    <SATNode>
+    <SatNode>
         <Description>I am a lovely sat node</Description>
         <Saturation>1.0128109381</Saturation>
-    </SATNode>
+    </SatNode>
 </ColorCorrection>
 """
 

--- a/tests/test_ccc.py
+++ b/tests/test_ccc.py
@@ -60,11 +60,11 @@ CCC_FULL = """<?xml version="1.0" encoding="UTF-8"?>
             <Description>Sop description 3</Description>
         </SOPNode>
         <Description>CC description 3</Description>
-        <SATNode>
+        <SatNode>
             <Description>Sat description 1</Description>
             <Saturation>1.09</Saturation>
             <Description>Sat description 2</Description>
-        </SATNode>
+        </SatNode>
         <Description>CC description 4</Description>
         <ViewingDescription>Viewing Desc Text</ViewingDescription>
         <Description>CC description 5</Description>
@@ -213,11 +213,11 @@ CCC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-0.00315 -0.00124 0.3103</Offset>
             <Power>1.0 0.9983 1.0</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Description>Sat description 1</Description>
             <Description>Sat description 2</Description>
             <Saturation>1.09</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f51.200">
         <SOPNode>
@@ -225,9 +225,9 @@ CCC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f55.100">
         <InputDescription>METAL VIEWER!!! \/\/</InputDescription>
@@ -240,9 +240,9 @@ CCC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-3424.011 -342789423.013 -4238923.11</Offset>
             <Power>3271893.993 0.0000998 0.0000000000000000113</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1798787.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f54.112">
         <SOPNode>
@@ -250,9 +250,9 @@ CCC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_100.x12">
         <SOPNode>
@@ -260,15 +260,15 @@ CCC_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-0.00315 -0.00124 0.3103</Offset>
             <Power>1.0 0.9983 1.0</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.09</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_200.x15">
-        <SATNode>
+        <SatNode>
             <Description>I am a lovely sat node</Description>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_300.x35">
         <SOPNode>
@@ -305,11 +305,11 @@ CCC_FULL_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-0.00315 -0.00124 0.3103</Offset>
                 <Power>1.0 0.9983 1.0</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Description>Sat description 1</Description>
                 <Description>Sat description 2</Description>
                 <Saturation>1.09</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -319,9 +319,9 @@ CCC_FULL_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>0.031 0.128 -0.096</Offset>
                 <Power>1.8 0.97 0.961</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -336,9 +336,9 @@ CCC_FULL_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-3424.011 -342789423.013 -4238923.11</Offset>
                 <Power>3271893.993 0.0000998 0.0000000000000000113</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1798787.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -348,9 +348,9 @@ CCC_FULL_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>0.031 0.128 -0.096</Offset>
                 <Power>1.8 0.97 0.961</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -360,17 +360,17 @@ CCC_FULL_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-0.00315 -0.00124 0.3103</Offset>
                 <Power>1.0 0.9983 1.0</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.09</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
         <ColorCorrection id="burp_200.x15">
-            <SATNode>
+            <SatNode>
                 <Description>I am a lovely sat node</Description>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -408,20 +408,20 @@ CCC_ODD_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
         </SOPNode>
     </ColorCorrection>
     <ColorCorrection id="f55.100">
-        <SATNode>
+        <SatNode>
             <Saturation>1798787.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f54.112">
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_200.x15">
-        <SATNode>
+        <SatNode>
             <Description>I am a lovely sat node</Description>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
 </ColorCorrectionCollection>
 """
@@ -454,24 +454,24 @@ CCC_ODD_WRITE_CDL = """<?xml version="1.0" encoding="UTF-8"?>
     </ColorDecision>
     <ColorDecision>
         <ColorCorrection id="f55.100">
-            <SATNode>
+            <SatNode>
                 <Saturation>1798787.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
         <ColorCorrection id="f54.112">
-            <SATNode>
+            <SatNode>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
         <ColorCorrection id="burp_200.x15">
-            <SATNode>
+            <SatNode>
                 <Description>I am a lovely sat node</Description>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
 </ColorDecisionList>
@@ -500,20 +500,20 @@ CCC_BAD_TAG = """<?xml version="1.0" encoding="UTF-8"?>
         </SOPNode>
     </ColorCorrection>
     <ColorCorrection id="f55.100">
-        <SATNode>
+        <SatNode>
             <Saturation>1798787.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f54.112">
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_200.x15">
-        <SATNode>
+        <SatNode>
             <Description>I am a lovely sat node</Description>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
 </ColorCorrectionBollection>
 """

--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -65,11 +65,11 @@ CDL_FULL = """<?xml version="1.0" encoding="UTF-8"?>
                 <Description>Sop description 3</Description>
             </SOPNode>
             <Description>CC description 3</Description>
-            <SATNode>
+            <SatNode>
                 <Description>Sat description 1</Description>
                 <Saturation>1.09</Saturation>
                 <Description>Sat description 2</Description>
-            </SATNode>
+            </SatNode>
             <Description>CC description 4</Description>
             <ViewingDescription>Viewing Desc Text</ViewingDescription>
             <Description>CC description 5</Description>
@@ -260,11 +260,11 @@ CDL_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-0.00315 -0.00124 0.3103</Offset>
                 <Power>1.0 0.9983 1.0</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Description>Sat description 1</Description>
                 <Description>Sat description 2</Description>
                 <Saturation>1.09</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -274,9 +274,9 @@ CDL_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>0.031 0.128 -0.096</Offset>
                 <Power>1.8 0.97 0.961</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -295,9 +295,9 @@ CDL_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-3424.011 -342789423.013 -4238923.11</Offset>
                 <Power>3271893.993 0.0000998 0.0000000000000000113</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1798787.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -310,9 +310,9 @@ CDL_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>0.031 0.128 -0.096</Offset>
                 <Power>1.8 0.97 0.961</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -322,9 +322,9 @@ CDL_FULL_WRITE = """<?xml version="1.0" encoding="UTF-8"?>
                 <Offset>-0.00315 -0.00124 0.3103</Offset>
                 <Power>1.0 0.9983 1.0</Power>
             </SOPNode>
-            <SATNode>
+            <SatNode>
                 <Saturation>1.09</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -359,11 +359,11 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-0.00315 -0.00124 0.3103</Offset>
             <Power>1.0 0.9983 1.0</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Description>Sat description 1</Description>
             <Description>Sat description 2</Description>
             <Saturation>1.09</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f51.200">
         <SOPNode>
@@ -371,9 +371,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f51.200">
         <SOPNode>
@@ -381,9 +381,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f55.100">
         <InputDescription>METAL VIEWER!!! \/\/</InputDescription>
@@ -396,9 +396,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-3424.011 -342789423.013 -4238923.11</Offset>
             <Power>3271893.993 0.0000998 0.0000000000000000113</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1798787.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f54.112">
         <SOPNode>
@@ -406,9 +406,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="burp_100.x12">
         <SOPNode>
@@ -416,9 +416,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>-0.00315 -0.00124 0.3103</Offset>
             <Power>1.0 0.9983 1.0</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.09</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f54.112">
         <SOPNode>
@@ -426,9 +426,9 @@ CDL_FULL_WRITE_CCC = """<?xml version="1.0" encoding="UTF-8"?>
             <Offset>0.031 0.128 -0.096</Offset>
             <Power>1.8 0.97 0.961</Power>
         </SOPNode>
-        <SATNode>
+        <SatNode>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
 </ColorCorrectionCollection>
 """
@@ -477,10 +477,10 @@ CDL_ODD_WRITE = r"""<?xml version="1.0" encoding="UTF-8"?>
     <ColorDecision>
         <MediaRef ref="serv://proto/uri:area:full?query=result#fragment"/>
         <ColorCorrection id="burp_200.x15">
-            <SATNode>
+            <SatNode>
                 <Description>I am a lovely sat node</Description>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -541,10 +541,10 @@ CDL_ODD_WRITE_RESOLVED = r"""<?xml version="1.0" encoding="UTF-8"?>
     <ColorDecision>
         <MediaRef ref="serv://proto/uri:area:full?query=result#fragment"/>
         <ColorCorrection id="burp_200.x15">
-            <SATNode>
+            <SatNode>
                 <Description>I am a lovely sat node</Description>
                 <Saturation>1.01</Saturation>
-            </SATNode>
+            </SatNode>
         </ColorCorrection>
     </ColorDecision>
     <ColorDecision>
@@ -588,10 +588,10 @@ CDL_ODD_WRITE_CCC = r"""<?xml version="1.0" encoding="UTF-8"?>
         </SOPNode>
     </ColorCorrection>
     <ColorCorrection id="burp_200.x15">
-        <SATNode>
+        <SatNode>
             <Description>I am a lovely sat node</Description>
             <Saturation>1.01</Saturation>
-        </SATNode>
+        </SatNode>
     </ColorCorrection>
     <ColorCorrection id="f51.200">
         <SOPNode>


### PR DESCRIPTION
Fixing the value of the saturation node XML tag.

Without this fix, conversion introduces an upper case SATNode in the CDL file that is not compatible with OCIO which specifically looks for a SatNode.

Couldn't find the ASC CDL specifications to know if SATNode is supposed to be supported too.

And while I'm here, thanks a lot for this lib :)