### PR TITLE
Nuke does not read CDL nodes  correctly if saturation element is "SATNode"

### DIFF
--- a/cdl_convert/cdl_convert.py
+++ b/cdl_convert/cdl_convert.py
@@ -144,6 +144,13 @@ def parse_args():
              "formats. This means that a single input CDL will export multiple "
              "CDL files, one per color decision."
     )
+    parser.add_argument(
+        "--nuke-support",
+        action='store_true',
+        dest='nuke_support',
+        help="change the output format of Saturation XML element to comply "
+             "with The Foundry's Nuke OCIO implementation."
+    )
 
     args = parser.parse_args()
 
@@ -184,6 +191,9 @@ def parse_args():
 
     if args.halt:
         config.HALT_ON_ERROR = True
+
+    if args.nuke_support:
+        config.NUKE_SATNODE_SUPPORT = True
 
     return args
 

--- a/cdl_convert/config.py
+++ b/cdl_convert/config.py
@@ -76,8 +76,10 @@ HALT_ON_ERROR = False
 COLLECTION_FORMATS = ['ale', 'ccc', 'cdl', 'edl', 'flex']
 SINGLE_FORMATS = ['cc', 'rcdl']
 
+NUKE_SATNODE_SUPPORT = False
+
 # ==============================================================================
 # EXPORTS
 # ==============================================================================
 
-__all__ = ['HALT_ON_ERROR']
+__all__ = ['HALT_ON_ERROR', 'NUKE_SATNODE_SUPPORT']

--- a/cdl_convert/correction.py
+++ b/cdl_convert/correction.py
@@ -143,7 +143,7 @@ class ColorCorrection(AscDescBase, AscColorSpaceBase, AscXMLBase):  # pylint: di
             Filepath this :class:`ColorCorrection` will be written to.
 
         has_sat : (bool)
-            Returns True if SOP values are set
+            Returns True if Saturation value is set
 
         has_sop : (bool)
             Returns True if SOP values are set
@@ -537,7 +537,8 @@ class SatNode(ColorNodeBase):
 
     def build_element(self):
         """Builds an ElementTree XML Element representing this SatNode"""
-        sat = ElementTree.Element('SATNode')
+        sat_elem_label = 'SatNode' if config.NUKE_SATNODE_SUPPORT else 'SATNode'
+        sat = ElementTree.Element(sat_elem_label)
         for description in self.desc:
             desc = ElementTree.SubElement(sat, 'Description')
             desc.text = description


### PR DESCRIPTION
Adding flag to switch the elem name to comply with Nuke