### PR TITLE
Update cdl_convert/parse.py to replace depreceated read mode 'rU'

### DIFF
--- a/cdl_convert/parse.py
+++ b/cdl_convert/parse.py
@@ -138,7 +138,7 @@ def parse_ale(input_file):  # pylint: disable=R0914
 
     cdls = []
 
-    with open(input_file, 'rU') as edl:
+    with open(input_file, 'r') as edl:
         lines = edl.readlines()
         for line in lines:
             if not line.strip():
@@ -474,7 +474,7 @@ def parse_cmx(input_file):  # pylint: disable=R0912,R0914
     """
     cdls = []
 
-    with open(input_file, 'rU') as edl:
+    with open(input_file, 'r') as edl:
         lines = edl.readlines()
 
     filename = os.path.basename(input_file).split('.')[0]
@@ -581,7 +581,7 @@ def parse_flex(input_file):  # pylint: disable=R0912,R0914
 
     cdls = []
 
-    with open(input_file, 'rU') as edl:
+    with open(input_file, 'r') as edl:
         lines = edl.readlines()
 
         filename = os.path.basename(input_file).split('.')[0]
@@ -706,7 +706,7 @@ def parse_rnh_cdl(input_file):
 
     """
 
-    with open(input_file, 'rU') as cdl_f:
+    with open(input_file, 'r') as cdl_f:
         # We only need to read the first line
         line = cdl_f.readline()
         line = line.split()


### PR DESCRIPTION
The 'rU' mode for universal newline support became the default behaviour in python 3, and is now depreciated. It can be safely replaced opening files with the standard 'r' mode.

It would break the library for python 2.7, but is this really a problem nowadays? I could implement checks for python version and logic to maintain 2.7 support if it's important for some reason.